### PR TITLE
changed to layerX and layerY to fix parent scroll issue 

### DIFF
--- a/fin-canvas.html
+++ b/fin-canvas.html
@@ -628,7 +628,7 @@ The `fin-canvas` element is a custom web component canvas control and includes a
                 }));
                 this.dragstart = this.g.point.create(this.mouseLocation.x, this.mouseLocation.y);
             }
-            this.mouseLocation = this.g.point.create(e.clientX - o.x, e.clientY - o.y);
+            this.mouseLocation = this.g.point.create(e.layerX, e.layerY);
             if (this.isDragging()) {
                 this.dispatchEvent(new CustomEvent('fin-drag', {
                     detail: {
@@ -658,7 +658,7 @@ The `fin-canvas` element is a custom web component canvas control and includes a
         finmousedown: function(e) {
 
             var o = this.getOrigin();
-            this.mouseLocation = this.g.point.create(e.clientX - o.x, e.clientY - o.y);
+            this.mouseLocation = this.g.point.create(e.layerX, e.layerY);
             this.mousedown = true;
 
             this.dispatchEvent(new CustomEvent('fin-mousedown', {
@@ -826,7 +826,7 @@ The `fin-canvas` element is a custom web component canvas control and includes a
                 return;
             }
             var o = this.getOrigin();
-            this.mouseLocation = this.g.point.create(e.clientX - o.x, e.clientY - o.y);
+            this.mouseLocation = this.g.point.create(e.layerX, e.layerY);
             this.dispatchEvent(new CustomEvent('fin-trackstart', {
                 detail: {
                     mouse: this.mouseLocation,
@@ -848,7 +848,7 @@ The `fin-canvas` element is a custom web component canvas control and includes a
                 return;
             }
             var o = this.getOrigin();
-            this.mouseLocation = this.g.point.create(e.clientX - o.x, e.clientY - o.y);
+            this.mouseLocation = this.g.point.create(e.layerX, e.layerY);
             this.dispatchEvent(new CustomEvent('fin-track', {
                 detail: {
                     mouse: this.mouseLocation,
@@ -867,7 +867,7 @@ The `fin-canvas` element is a custom web component canvas control and includes a
          */
         fintrackend: function(e) {
             var o = this.getOrigin();
-            this.mouseLocation = this.g.point.create(e.clientX - o.x, e.clientY - o.y);
+            this.mouseLocation = this.g.point.create(e.layerX, e.layerY);
             this.dispatchEvent(new CustomEvent('fin-trackend', {
                 detail: {
                     mouse: this.mouseLocation,


### PR DESCRIPTION
This is relative to: https://github.com/openfin/fin-hypergrid/issues/15. So now clicks are good regardless what the parent's scroll state is: 
![fixed click](https://cloud.githubusercontent.com/assets/99223/6214273/238443de-b5ef-11e4-9bdd-936f539c7a83.gif)
